### PR TITLE
feat: Persistent flags

### DIFF
--- a/app.fluxer.Fluxer.sh
+++ b/app.fluxer.Fluxer.sh
@@ -1,2 +1,9 @@
 #!/bin/sh
-exec zypak-wrapper /app/fluxer/fluxer_desktop "$@"
+
+FLAGS_PATH="${XDG_CONFIG_HOME}/fluxer-flags.conf"
+
+if [ -f "${FLAGS_PATH}" ]; then
+    mapfile -t FLAGS <<< "$(grep -Ev '^\s*$|^#' "${FLAGS_PATH}")"
+fi
+
+exec zypak-wrapper /app/fluxer/fluxer_desktop "${FLAGS[@]}" "$@"


### PR DESCRIPTION
Adds support for persistent launch flags via `fluxer-flags.conf`. Users can create the file at `~/.var/app/app.fluxer.Fluxer/config/fluxer-flags.conf` to define flags that are automatically applied on startup, removing the need to launch the app via CLI each time.

This mirrors the behavior used by other Flatpak apps like Discord and Spotify.
