### PR TITLE
Remove PipeWire permissions

### DIFF
--- a/app.fluxer.Fluxer.yml
+++ b/app.fluxer.Fluxer.yml
@@ -15,7 +15,6 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --device=all
-  - --filesystem=xdg-run/pipewire-0:ro
   - --filesystem=xdg-run/speech-dispatcher:ro
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
Screensharing uses the XDG portal, webcams go through `device=all`, and sound goes through PulseAudio, so there is no reason for Fluxer to access the PipeWire socket.