### PR TITLE
fix: work around zypak on x11

### DIFF
--- a/app.fluxer.Fluxer.sh
+++ b/app.fluxer.Fluxer.sh
@@ -6,4 +6,8 @@ if [ -f "${FLAGS_PATH}" ]; then
     mapfile -t FLAGS <<< "$(grep -Ev '^\s*$|^#' "${FLAGS_PATH}")"
 fi
 
-exec zypak-wrapper /app/fluxer/fluxer_desktop "${FLAGS[@]}" "$@"
+if [ -n "$WAYLAND_DISPLAY" ]; then
+    exec zypak-wrapper /app/fluxer/fluxer_desktop "${FLAGS[@]}" "$@"
+else
+    exec /app/fluxer/fluxer_desktop --no-sandbox "${FLAGS[@]}" "$@"
+fi


### PR DESCRIPTION
Temporary workaround for https://github.com/flathub/app.fluxer.Fluxer/issues/1 until a fix is implemented

To remove the need for users to run this via CLI everytime and less friction for new users (mint seems quite popular) 

